### PR TITLE
Percent pipe

### DIFF
--- a/src/pipes/percent.pipe.ts
+++ b/src/pipes/percent.pipe.ts
@@ -9,7 +9,6 @@ export class PercentPipe implements PipeTransform{
             round = round || false;
             divided = divided || 100;
             if(isNaN(value) || !Number(value)) return value;
-            let persentResult =  round ? Math.round((value / divided) * 100) : (value / divided) * 100;          
-            return persentResult;
+            return round ? Math.round((value / divided) * 100) : (value / divided) * 100;          
         }
 }

--- a/src/pipes/percent.pipe.ts
+++ b/src/pipes/percent.pipe.ts
@@ -1,0 +1,15 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe( {
+  name:'percent'
+})
+
+export class PercentPipe implements PipeTransform{
+        transform(value:number, divided:any, round:boolean):number{
+            round = round || false;
+            divided = divided || 100;
+            if(isNaN(value) || !Number(value)) return value;
+            let persentResult =  round ? Math.round((value / divided) * 100) : (value / divided) * 100;          
+            return persentResult;
+        }
+}


### PR DESCRIPTION
percent pipe.
Usage: number | percent: total: round\[optional\] (round by default false).

**For Example:**
\<p>{{ 23 | percent: 500 }}\</p>
\<p>{{ 23 | percent: 500: true }}\</p>

the result: 
4.6 
5

 [Percent pipe code in angular1](https://github.com/a8m/angular-filter/blob/master/src/_filter/math/percent.js)